### PR TITLE
Assign resident status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In place of release version numbers, we organize via deploys to Production (by D
 - Fix first column show of models_table
 - seed: add chairman
 - db: config for heroku's DATABASE_URL
+- Login: increase width of email field
 
 ## 2022/10/11: Revised Import, Add gem: nilify_blanks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ In place of release version numbers, we organize via deploys to Production (by D
 
 - Allow user to add a Resident on properties#show
 - Fix first column show of models_table
+- Residency:
+  - verified? is based on resident_status (not verified_on)
 - seed: add chairman, support
 - db: config for heroku's DATABASE_URL
 - Login: increase width of email field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ In place of release version numbers, we organize via deploys to Production (by D
 - seed: add chairman
 - db: config for heroku's DATABASE_URL
 - Login: increase width of email field
+- Create Footer: link to Github Issues
+- Helpers
+  - Add external_link_to
 
 ## 2022/10/11: Revised Import, Add gem: nilify_blanks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ In place of release version numbers, we organize via deploys to Production (by D
 
 - Allow user to add a Resident on properties#show
 - Fix first column show of models_table
-- seed: add chairman
+- seed: add chairman, support
 - db: config for heroku's DATABASE_URL
 - Login: increase width of email field
 - Create Footer: link to Github Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ In place of release version numbers, we organize via deploys to Production (by D
 
 ## Upcoming: Add Resident on properties#show
 
-- Allow user to add a Resident on properties#show
+- property#show
+  - Can add a Resident to a Property
+  - Can assign resident_type
 - Fix first column show of models_table
 - Residency:
   - verified? is based on resident_status (not verified_on)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Not only do we need to gather and manage the approprite information, we need to 
 
 
 ### TODO
+  - Meeting 2023/01/08
+    - Remove Resident from Property (for ownership transfer)
   - Meeting 2022/09/11
     - ~~Move TaxID to Property~~
     - Import from new spreadsheet

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -110,6 +110,15 @@ form {
   }
 }
 
+footer {
+  // background-color: $color-secondary;
+  padding: $padding-default;
+
+  #links {
+    justify-content: flex-end;
+  }
+}
+
 h1, h2, h3, h4, h5 {
   font-family:Verdana, Geneva, Tahoma, sans-serif;
   font-weight: 500;
@@ -170,6 +179,10 @@ i.busy {
 // login
 input[name="login"] {
   width: 30em;
+}
+
+li .list-delimiter {
+  color: $color-secondary;
 }
 
 main {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -167,6 +167,11 @@ i.busy {
   }
 }
 
+// login
+input[name="login"] {
+  width: 30em;
+}
+
 main {
   clear: both;
 }

--- a/app/controllers/residencies_controller.rb
+++ b/app/controllers/residencies_controller.rb
@@ -33,7 +33,8 @@ class ResidenciesController < ApplicationController
 
     def residency_params
       params.require(:residency).permit(
-        :verified_on,
+        :resident_status,
+        :verified_on
       )
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,13 @@ module ApplicationHelper
     content_tag(:span, "#{time_ago_in_words(datetime)} ago", class: "datetime", data: { tooltip: formatted_datetime})
   end
 
+  # Creates a link to an external resource
+  # Follows the Rails' link_to signature
+  def external_link_to(name = nil, options = nil, html_options = {}, &block)
+    default_html_options = { class: 'external', target: '_blank' }
+    link_to(name, options, default_html_options.merge(html_options))
+  end
+
   def icon_for_scope(scope_name)
     case scope_name.to_s
     when /border/
@@ -78,6 +85,10 @@ module ApplicationHelper
       icon = flash_icon_name(flash_type)
       font_awesome_icon(icon, caption: caption) + "&nbsp;".html_safe + message
     end
+  end
+
+  def list_delimiter
+    content_tag(:span, '|', class: 'list-delimiter')
   end
 
   def menu_list_item(caption, url_options, html_options={})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,7 +58,7 @@ module ApplicationHelper
       'road'
     when /sun/
       'sun'
-    when /without_resident_status/
+    when /resident_status/
       'tent'
     when /verified/
       'certificate'

--- a/app/helpers/residents_helper.rb
+++ b/app/helpers/residents_helper.rb
@@ -1,2 +1,24 @@
 module ResidentsHelper
+  def resident_status_character(resident_status, is_minor)
+    # debugger
+    return '' if is_minor # child
+
+    case resident_status
+    when nil
+      '⁇'
+    when :border.to_s
+      '' # people-robbery
+    when /owner/, :trustee.to_s
+      '' # gavel
+    when :renter.to_s
+      '' # suitcase
+    when :dependent.to_s
+      # '' # family, pro
+      '' # user-graduate
+    when :significant_other.to_s
+      '' # user-group
+    else
+      raise NotImplementedError, "Unknown resident_status: #{resident_status.inspect}"
+    end
+  end
 end

--- a/app/models/residency.rb
+++ b/app/models/residency.rb
@@ -34,8 +34,8 @@ class Residency < ApplicationRecord
   scope :without_primary_residence, -> { where(primary_residence: false).or(where(primary_residence: nil)) }
   scope :with_resident_status, -> { where.not(id: without_resident_status) }
   scope :without_resident_status, -> { where(resident_status: nil) }
-  scope :verified, -> { where.not(verified_on: nil) }
-  scope :not_verified, -> { where(verified_on: nil) }
+  scope :verified, -> { where.not(resident_status: nil) }
+  scope :not_verified, -> { where(resident_status: nil) }
 
   validates :primary_residence, uniqueness: {
     if: -> { primary_residence? },
@@ -83,6 +83,6 @@ class Residency < ApplicationRecord
   end
 
   def verified?
-    !resident_status?
+    resident_status?
   end
 end

--- a/app/models/resident.rb
+++ b/app/models/resident.rb
@@ -18,7 +18,7 @@ class Resident < ApplicationRecord
   scope :lot_fees_paid, -> {
     # basic "joins" to property returns resident where ANY lots fees are paid,
     #   this returns those where ALL lot fees are paid
-    distinct.where.not(id: lot_fees_not_paid)
+    where.not(id: lot_fees_not_paid)
   }
   scope :lot_fees_not_paid, -> {
     distinct.joins(:lots).merge(Lot.lot_fees_not_paid)

--- a/app/views/layouts/_models_table.slim
+++ b/app/views/layouts/_models_table.slim
@@ -66,6 +66,13 @@
             td= button_to "Destroy", model, method: :delete
 
 javascript:
+  function updateResidentStatus(target) {
+    form = jQuery(target).siblings('form');
+    console.debug("submitForm", 'form:', form, 'target:', target);
+    form.trigger('submit.rails');
+    // form.submit();
+  }
+
   function updateVerifiedOn(target) {
     form = jQuery(target).siblings('form');
     console.debug("submitForm", 'form:', form, 'target:', target);

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -59,6 +59,18 @@ html lang=I18n.locale
     main.container
       = yield
 
+    footer
+      ul#links.horizontal-list
+        li= link_to font_awesome_icon('umbrella-beach'), '/', class: 'no-link-icon'
+        li= list_delimiter
+        li= external_link_to("Issues (on GitHub)", 'https://github.com/mattscilipoti/abi_registrar/issues')
+        li= list_delimiter
+        li
+          small &copy; Copyright 2023
+        li= list_delimiter
+        li
+          small Crafted with 💜 in MD
+
 javascript:
   //TODO: move to isolated javascript file
   function indicateBusySearch(event) {

--- a/app/views/properties/_property.html.slim
+++ b/app/views/properties/_property.html.slim
@@ -23,7 +23,7 @@ fieldset
     h2
       | Residents
       small= "(#{property.residents.size} ct.)"
-  - columns = %i[resident resident_status_link_tag email_address primary_residence?]
+  - columns = %i[resident resident_updatable_status_link_tag email_address primary_residence?]
   =render 'layouts/models_table', models: property.residencies.includes(:resident).decorate, columns: columns, allow_edit: false, allow_show: :resident
 
   = link_to("Add Resident to Property", new_resident_path(resident: { residencies_attributes: { property_id: property } }))

--- a/app/views/residencies/_resident_icon_list.html.slim
+++ b/app/views/residencies/_resident_icon_list.html.slim
@@ -1,4 +1,4 @@
 ul.horizontal-list
   - residencies.each do |residency|
     li.residenct-icon
-      = residency.resident_status_link_tag
+      = residency.resident_status_link_tag(show_resident: true)

--- a/app/views/rodauth/_email_auth_request_form.html.erb
+++ b/app/views/rodauth/_email_auth_request_form.html.erb
@@ -1,4 +1,6 @@
-OR we can send you an email with a link that will log you in:
+<br/>
+<strong>OR</strong>
+we can send you an email with a link that will log you in:
 <%= form_with url: rodauth.email_auth_request_path, method: :post, data: { turbo: false } do |form| %>
   <%= form.hidden_field rodauth.login_param, value: params[rodauth.login_param] %>
 
@@ -6,3 +8,4 @@ OR we can send you an email with a link that will log you in:
     <%= form.submit rodauth.email_auth_request_button, class: "btn btn-primary" %>
   </div>
 <% end %>
+<hr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -117,5 +117,10 @@ end
 
 Account.find_or_create_by(email: 'chairman@ardenbeachesinc.com') do |account|
   account.password_hash = BCrypt::Password.create(Rails.application.credentials.fetch(:temporary_password)).to_s
-  # account.status = 2 # verified
+  account.status = 2 # verified
+end
+
+Account.find_or_create_by(email: 'support@ardenbeachesinc.com') do |account|
+  account.password_hash = BCrypt::Password.create(Rails.application.credentials.fetch(:temporary_password)).to_s
+  account.status = 2 # verified
 end

--- a/spec/models/residency_spec.rb
+++ b/spec/models/residency_spec.rb
@@ -74,5 +74,19 @@ RSpec.describe Residency, type: :model do
         expect(subject.deed_holder?).to be false
       end
     end
+
+    describe '#verified?' do
+      it 'returns true if has resident_status' do
+        subject.owner!
+        expect(subject.owner?).to eql true
+        expect(subject.resident_status).to eql 'owner'
+        expect(subject.verified?).to eql true
+      end
+
+      it 'returns false if does NOT have resident_status' do
+        subject.resident_status = nil
+        expect(subject.verified?).to eql false
+      end
+    end
   end
 end


### PR DESCRIPTION
Add Resident on properties#show

- property#show
  - Can add a Resident to a Property
  - Can assign resident_type
- Fix first column show of models_table
- Residency:
  - verified? is based on resident_status (not verified_on)
- seed: add chairman, support
- db: config for heroku's DATABASE_URL
- Login: increase width of email field
- Create Footer: link to Github Issues
- Helpers
  - Add external_link_to