### PR TITLE
Closes: Can only add properties to Residents #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 In place of release version numbers, we organize via deploys to Production (by Date/Time).
 
+## Upcoming: [#38](https://github.com/mattscilipoti/abi_registrar/issues/38) Add Property to Resident, not Resident to Property
+
+- Removes the ability to add a Resident to a Property (when looking at a Property), instead you add Properties to a Resident. We didn't see a way for you to search through existing Residents. Forcing this through a Resident, encourages us to search first, but we can add new one when we need to.
+
 ## 2023/01/29: [#34](https://github.com/mattscilipoti/abi_registrar/issues/34), Mark Properties For Sale
 
 - Can mark properties for sale, in edit or index

--- a/app/controllers/residents_controller.rb
+++ b/app/controllers/residents_controller.rb
@@ -14,11 +14,6 @@ class ResidentsController < ApplicationController
   # GET /residents/new
   def new
     @resident = Resident.new
-    if params[:resident]
-      property_id = resident_params[:residencies_attributes][:property_id]
-      @property = Property.find(property_id)
-      @resident.residencies.build(property: @property)
-    end
   end
 
   # GET /residents/1/edit

--- a/app/views/properties/_property.html.slim
+++ b/app/views/properties/_property.html.slim
@@ -30,7 +30,7 @@ fieldset
   - columns = %i[resident resident_updatable_status_link_tag email_address primary_residence?]
   =render 'layouts/models_table', models: property.residencies.includes(:resident).decorate, columns: columns, allow_edit: false, allow_show: :resident
 
-  = link_to("Add Resident to Property", new_resident_path(resident: { residencies_attributes: { property_id: property } }))
+  p Note: Properties are assigned to #{link_to('existing Residents', residents_path(q: '🚫'))}
 
 fieldset
   legend

--- a/app/views/residents/new.html.erb
+++ b/app/views/residents/new.html.erb
@@ -1,8 +1,4 @@
-<h1>New resident
-  <%- if @property %>
-  <small><%= "(for #{@property})"%></small>
-  <%- end %>
-</h1>
+<h1>New resident</h1>
 
 <%= render "form", resident: @resident %>
 


### PR DESCRIPTION
Removes the ability to add a Resident to a Property (when looking at a Property), instead you add Properties to a Resident. We didn't see a way for you to search through existing Residents. Forcing this through a Resident, encourages us to search first, but we can add new one when we need to.