### PR TITLE
Rename Dinghy Dock Storage Location to Slip Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ In place of release version numbers, we organize via deploys to Production (by D
 - rails db:delete_item_transactions
 - rails db:delete_test_data
 
-## 2025-11-18: 111 Manage UtilityCartPasses, includes conversion
+## 2025-05-03: Rename Dinghy Dock Storage Location to Slip Number
+
+- Add decorator to show dinghy dock storage pass location field to be Slip Number
+
+## 2024-11-18: 111 Manage UtilityCartPasses, includes conversion
 
 - Add UtilityCartPass (and UI for managing)
   - Add to Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 In place of release version numbers, we organize via deploys to Production (by Date/Time).
 
-## Upcoming: Added sorting per Amenity Pass type
+## 2025-05-08: Rename Dinghy Dock Storage Location to Slip Number
 
-## Upcoming: 105 Delete Test Data
+- Add decorator to show dinghy dock storage pass location field to be Slip Number
+
+## 2025-05-06: Added sorting per Amenity Pass type
+
+## 2025-04-23: 105 Delete Test Data
 
 - rails db:delete_item_transactions
 - rails db:delete_test_data
-
-## 2025-05-03: Rename Dinghy Dock Storage Location to Slip Number
-
-- Add decorator to show dinghy dock storage pass location field to be Slip Number
 
 ## 2024-11-18: 111 Manage UtilityCartPasses, includes conversion
 

--- a/app/decorators/dinghy_dock_storage_pass_decorator.rb
+++ b/app/decorators/dinghy_dock_storage_pass_decorator.rb
@@ -13,4 +13,8 @@ class DinghyDockStoragePassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('dinghy')
   end
+
+  def slip_number
+    object.location
+  end
 end

--- a/app/views/dinghy_dock_storage_passes/_dinghy_dock_storage_pass.html.slim
+++ b/app/views/dinghy_dock_storage_passes/_dinghy_dock_storage_pass.html.slim
@@ -6,7 +6,7 @@ div id="#{dom_id dinghy_dock_storage_pass}"
     strong Beach Number:
     =< dinghy_dock_storage_pass.beach_number
   p
-    strong Slip Number:
+    strong Location:
     =< dinghy_dock_storage_pass.location
   p
     strong Description:

--- a/app/views/dinghy_dock_storage_passes/_dinghy_dock_storage_pass.html.slim
+++ b/app/views/dinghy_dock_storage_passes/_dinghy_dock_storage_pass.html.slim
@@ -6,7 +6,7 @@ div id="#{dom_id dinghy_dock_storage_pass}"
     strong Beach Number:
     =< dinghy_dock_storage_pass.beach_number
   p
-    strong Location:
+    strong Slip Number:
     =< dinghy_dock_storage_pass.location
   p
     strong Description:

--- a/app/views/dinghy_dock_storage_passes/_form.html.slim
+++ b/app/views/dinghy_dock_storage_passes/_form.html.slim
@@ -7,7 +7,7 @@
   .form-inputs
     = f.input :sticker_number
     = f.input :beach_number
-    = f.input :location
+    = f.input :location, label: 'Slip Number'
     = f.input :description, as: :text, input_html: { rows: 2, cols: 60 }
     = f.association :resident, collection: possible_residents
 

--- a/app/views/dinghy_dock_storage_passes/index.html.slim
+++ b/app/views/dinghy_dock_storage_passes/index.html.slim
@@ -5,7 +5,7 @@ fieldset
     = render 'layouts/h1', title: "Dinghy Dock Storage Passes", model_count: @dinghy_dock_storage_passes.size, model_total: DinghyDockStoragePass.count
 
   #dinghy_dock_storage_passes
-    - columns = %i[sticker_number beach_number location description resident property_summary]
+    - columns = %i[sticker_number beach_number slip_number description resident property_summary]
     =render 'layouts/models_table', models: @dinghy_dock_storage_passes, columns: columns, allow_sort: true
 br
 = link_to "New Dinghy Dock Storage Pass", new_dinghy_dock_storage_pass_path


### PR DESCRIPTION
The Dinghy Dock Storage Pass's Location field has been renamed to Slip Number via a decorator.  No changes to the database.

I also noticed that in the changelog, one of the dates was wrong (said 2025 instead of 2024), which is corrected here.