### PR TITLE
Changed Boat Ramp Access Pass Tag Number to Tag and/or Vessel Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In place of release version numbers, we organize via deploys to Production (by D
 - rails db:delete_item_transactions
 - rails db:delete_test_data
 
+## 2025-05-03: Changed Boat Ramp Access Pass Tag Number to Tag and/or Vessel Number
+
+- Add substition to models_table layout for "And Or" -> "and/or"
+
 ## 2025-11-18: 111 Manage UtilityCartPasses, includes conversion
 
 - Add UtilityCartPass (and UI for managing)

--- a/app/decorators/boat_ramp_access_pass_decorator.rb
+++ b/app/decorators/boat_ramp_access_pass_decorator.rb
@@ -13,4 +13,8 @@ class BoatRampAccessPassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('boat')
   end
+
+  def tag_and_or_vessel_number
+    object.tag_number
+  end
 end

--- a/app/views/boat_ramp_access_passes/_boat_ramp_access_pass.html.slim
+++ b/app/views/boat_ramp_access_passes/_boat_ramp_access_pass.html.slim
@@ -3,7 +3,7 @@ div id="#{dom_id boat_ramp_access_pass}"
     strong Sticker number:
     =< boat_ramp_access_pass.sticker_number
   p
-    strong Tag Number:
+    strong Tag and/or Vessel Number:
     =< boat_ramp_access_pass.tag_number
   p
     strong State Code:

--- a/app/views/boat_ramp_access_passes/_form.html.slim
+++ b/app/views/boat_ramp_access_passes/_form.html.slim
@@ -6,7 +6,7 @@
 
   .form-inputs
     = f.input :sticker_number
-    = f.input :tag_number
+    = f.input :tag_number, label: 'Tag and/or Vessel Number'
     = f.input :state_code, collection: AmenityPass.states
     = f.input :description, as: :text, input_html: { rows: 2, cols: 60 }
     = f.association :resident, collection: possible_residents

--- a/app/views/boat_ramp_access_passes/index.html.slim
+++ b/app/views/boat_ramp_access_passes/index.html.slim
@@ -5,7 +5,7 @@ fieldset
     = render 'layouts/h1', title: "Boat Ramp Access Passes", model_count: @boat_ramp_access_passes.size, model_total: BoatRampAccessPass.count
 
   #boat_ramp_access_passes
-    - columns = %i[sticker_number tag_number description resident property_summary]
+    - columns = %i[sticker_number tag_and_or_vessel_number description resident property_summary]
     =render 'layouts/models_table', models: @boat_ramp_access_passes, columns: columns, allow_sort: true
 br
 = link_to "New Boat Ramp Access Pass", new_boat_ramp_access_pass_path

--- a/app/views/layouts/_models_table.slim
+++ b/app/views/layouts/_models_table.slim
@@ -17,7 +17,7 @@
     thead
       - for column_name in columns do
         - excluded_name_adjusters = ['_as_icon', '_i18n', '_link_tag', '_tag', 'toggleable_']
-        - column_caption = column_name.to_s.gsub(Regexp.union(excluded_name_adjusters), '').titleize
+        - column_caption = column_name.to_s.gsub(Regexp.union(excluded_name_adjusters), '').titleize.gsub("And Or", "and/or")
         - index_path = models.first.class.table_name
         - css_classes = []
         - css_classes << 'boolean' if column_name.ends_with?('?')


### PR DESCRIPTION
Renamed "Tag Number" to "Tag and/or Vessel Number" for Boat Ramp Access Pass.

Part of this required changes to layout/_model_table.slim, where it now does a substitution for "And Or" to "and/or".  Maybe there is a cleaner way to achieve this for the column names, but it was the only solution I could come up with in my limited knowledge of this ecosystem.