### PR TITLE
Enabled sorting within a specific type of Amenity Pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 In place of release version numbers, we organize via deploys to Production (by Date/Time).
 
-## Upcoming: 105 Delete Test Data
+## 2025-05-04: Enabled sorting within a specific type of Amenity Pass
 
-- rails db:delete_item_transactions
-- rails db:delete_test_data
+- Explicitly defined table_name for each class that inherits from AmenityPass
 
 ## 2025-11-18: 111 Manage UtilityCartPasses, includes conversion
 

--- a/app/decorators/beach_pass_decorator.rb
+++ b/app/decorators/beach_pass_decorator.rb
@@ -13,4 +13,8 @@ class BeachPassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('beach_pass')
   end
+
+  def self.table_name
+    'beach_passes'
+  end
 end

--- a/app/decorators/boat_ramp_access_pass_decorator.rb
+++ b/app/decorators/boat_ramp_access_pass_decorator.rb
@@ -13,4 +13,8 @@ class BoatRampAccessPassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('boat')
   end
+
+  def self.table_name
+    'boat_ramp_access_passes'
+  end
 end

--- a/app/decorators/dinghy_dock_storage_pass_decorator.rb
+++ b/app/decorators/dinghy_dock_storage_pass_decorator.rb
@@ -13,4 +13,8 @@ class DinghyDockStoragePassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('dinghy')
   end
+
+  def self.table_name
+    'dinghy_dock_storage_passes'
+  end
 end

--- a/app/decorators/utility_cart_pass_decorator.rb
+++ b/app/decorators/utility_cart_pass_decorator.rb
@@ -13,4 +13,8 @@ class UtilityCartPassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('utility_cart')
   end
+
+  def self.table_name
+    'utility_cart_passes'
+  end
 end

--- a/app/decorators/vehicle_parking_pass_decorator.rb
+++ b/app/decorators/vehicle_parking_pass_decorator.rb
@@ -13,4 +13,8 @@ class VehicleParkingPassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('parking')
   end
+
+  def self.table_name
+    'vehicle_parking_passes'
+  end
 end

--- a/app/decorators/watercraft_storage_pass_decorator.rb
+++ b/app/decorators/watercraft_storage_pass_decorator.rb
@@ -13,4 +13,8 @@ class WatercraftStoragePassDecorator < AmenityPassDecorator
   def self.icon_name
     helpers.icon_for_scope('watercraft')
   end
+
+  def self.table_name
+    'watercraft_storage_passes'
+  end
 end

--- a/app/views/dinghy_dock_storage_passes/_form.html.slim
+++ b/app/views/dinghy_dock_storage_passes/_form.html.slim
@@ -7,7 +7,7 @@
   .form-inputs
     = f.input :sticker_number
     = f.input :beach_number
-    = f.input :location
+    = f.input :location, label: 'Slip Number'
     = f.input :description, as: :text, input_html: { rows: 2, cols: 60 }
     = f.association :resident, collection: possible_residents
 

--- a/app/views/dinghy_dock_storage_passes/index.html.slim
+++ b/app/views/dinghy_dock_storage_passes/index.html.slim
@@ -5,7 +5,7 @@ fieldset
     = render 'layouts/h1', title: "Dinghy Dock Storage Passes", model_count: @dinghy_dock_storage_passes.size, model_total: DinghyDockStoragePass.count
 
   #dinghy_dock_storage_passes
-    - columns = %i[sticker_number beach_number location description resident property_summary]
+    - columns = %i[sticker_number beach_number slip_number description resident property_summary]
     =render 'layouts/models_table', models: @dinghy_dock_storage_passes, columns: columns, allow_sort: true
 br
 = link_to "New Dinghy Dock Storage Pass", new_dinghy_dock_storage_pass_path


### PR DESCRIPTION
Previously, when sorting by any column under a specific type of Amenity Passes (e.g., Beach Passes), it would redirect to look under Amenity Passes in general, which includes other types of passes beyond what the user was looking at. I traced this to the table_name for the classes pointing to amenity_passes, so in each decorator I explicitly set the table_name. Might be able to do this in a cleaner way where this is automatically applied from the class name, but I'm not entirely sure how to do that in Ruby yet so I went with the quick and dirty solution for now.

(I just submitted this, but realized I accidentally branched from the edit made in #117 so I fixed that and re-made this PR.)